### PR TITLE
Fix string comparison logic in mem_read

### DIFF
--- a/OCaml/run_mem_read/mem_read.ml
+++ b/OCaml/run_mem_read/mem_read.ml
@@ -131,7 +131,14 @@ let is_readables_opt subs n =
   match subs with
     | Some r -> if String.equal (Re.Group.get r n) "r" then true else false
     | None -> false  
-let readables = List.filter (fun x -> if x != "" then is_readables_opt (Re.exec_opt myregex x ) 3 else false) inlst
+let readables =
+  List.filter
+    (fun x ->
+      if not (String.equal x "") then
+        is_readables_opt (Re.exec_opt myregex x) 3
+      else
+        false)
+    inlst
 
 let triples = get_mem_regions myregex readables g
 


### PR DESCRIPTION
## Summary
- fix string comparison bug in `mem_read.ml`

## Testing
- `dune build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc84e491083219d880609edd97e04