### PR TITLE
Fix comment wording

### DIFF
--- a/BAP/get_func_params/lisp_files/entry.lisp
+++ b/BAP/get_func_params/lisp_files/entry.lisp
@@ -1,4 +1,4 @@
-;; Use this lisp file if you wish to over-ride the parameters which occur within test.c
+;; Use this lisp file if you wish to override the parameters which occur within test.c
 ;; for func0.
 (defun entry-func0 () 
   (declare (external entry-func0)) 


### PR DESCRIPTION
## Summary
- typo fix in BAP entry.lisp (over-ride -> override)

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683fd0d31ef08321a2d9dff5d2e74037