### PR TITLE
Fix recursion in get_mem_regions

### DIFF
--- a/OCaml/run_mem_read/mem_read.ml
+++ b/OCaml/run_mem_read/mem_read.ml
@@ -135,8 +135,8 @@ let rec get_mem_regions regex lst f =
   (*let open Re in*)
   match lst with
   | [] -> []
-  | [x] -> (f (get_subs regex x) )  :: get_mem_regions regex [] g
-  | h::t -> (f (get_subs regex h) )  :: get_mem_regions regex t g
+  | [x] -> (f (get_subs regex x) )  :: get_mem_regions regex [] f
+  | h::t -> (f (get_subs regex h) )  :: get_mem_regions regex t f
 
 let is_readables_opt subs n =
   (*let open Re in*)


### PR DESCRIPTION
## Summary
- ensure recursive calls to `get_mem_regions` reuse the provided mapping function

## Testing
- `dune build` *(fails: cannot find root of workspace)*

------
https://chatgpt.com/codex/tasks/task_e_683fd32dc4d4832197dfef5b81f46243